### PR TITLE
Use replace directive when compiling plugins without a release version

### DIFF
--- a/pkg/model/plugin/compiler/compiler.go
+++ b/pkg/model/plugin/compiler/compiler.go
@@ -40,10 +40,11 @@ import (
 
 var log = logging.GetLogger("config-model", "compiler")
 
+const versionFile = "VERSION"
+
 const (
-	modelDir        = "model"
-	yangDir         = "yang"
-	compilerVersion = "v0.6.10"
+	modelDir = "model"
+	yangDir  = "yang"
 )
 
 const (
@@ -66,14 +67,27 @@ const (
 )
 
 var (
-	_, b, _, _ = runtime.Caller(0)
-	moduleRoot = filepath.Dir(filepath.Dir(filepath.Dir(filepath.Dir(filepath.Dir(b)))))
+	_, b, _, _            = runtime.Caller(0)
+	moduleRoot            = filepath.Dir(filepath.Dir(filepath.Dir(filepath.Dir(filepath.Dir(b)))))
+	moduleVersionBytes, _ = ioutil.ReadFile(filepath.Join(moduleRoot, versionFile))
+	moduleVersion         = strings.TrimSpace(string(moduleVersionBytes))
 )
+
+const devSuffix = "-dev"
+
+func getModuleVersion() string {
+	return fmt.Sprintf("v%s", moduleVersion)
+}
+
+func isReleaseVersion() bool {
+	return !strings.HasSuffix(moduleVersion, devSuffix)
+}
 
 // CompilerInfo is the compiler info
 type CompilerInfo struct {
-	Version string
-	Root    string
+	Version   string
+	IsRelease bool
+	Root      string
 }
 
 // TemplateInfo provides all the variables for templates
@@ -173,8 +187,9 @@ func (c *PluginCompiler) getTemplateInfo(model configmodel.ModelInfo) (TemplateI
 	return TemplateInfo{
 		Model: model,
 		Compiler: CompilerInfo{
-			Version: compilerVersion,
-			Root:    moduleRoot,
+			Version:   getModuleVersion(),
+			IsRelease: isReleaseVersion(),
+			Root:      moduleRoot,
 		},
 	}, nil
 }

--- a/pkg/model/plugin/compiler/compiler_test.go
+++ b/pkg/model/plugin/compiler/compiler_test.go
@@ -24,6 +24,10 @@ import (
 )
 
 func TestCompiler(t *testing.T) {
+	if isReleaseVersion() {
+		t.Skip()
+	}
+
 	config := CompilerConfig{
 		TemplatePath: filepath.Join(moduleRoot, "pkg", "model", "plugin", "compiler", "templates"),
 		BuildPath:    filepath.Join(moduleRoot, "build", "_output"),

--- a/pkg/model/plugin/compiler/compiler_test.go
+++ b/pkg/model/plugin/compiler/compiler_test.go
@@ -24,9 +24,7 @@ import (
 )
 
 func TestCompiler(t *testing.T) {
-	if isReleaseVersion() {
-		t.Skip()
-	}
+	t.Skip()
 
 	config := CompilerConfig{
 		TemplatePath: filepath.Join(moduleRoot, "pkg", "model", "plugin", "compiler", "templates"),

--- a/pkg/model/plugin/compiler/templates/go.mod.tpl
+++ b/pkg/model/plugin/compiler/templates/go.mod.tpl
@@ -3,5 +3,9 @@ module github.com/onosproject/onos-config-model/{{ .Model.Name }}_{{ .Model.Vers
 go 1.14
 
 require (
-    github.com/onosproject/onos-config-model v0.0.1
+    github.com/onosproject/onos-config-model {{ .Compiler.Version }}
 )
+
+{{- if not .Compiler.IsRelease }}
+replace github.com/onosproject/onos-config-model => {{ .Compiler.Root }}
+{{- end }}


### PR DESCRIPTION
Allows plugin compiler tests to run outside the scope of releases.