### PR TITLE
Use file lock for concurrency control across containers in registry

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/onosproject/onos-config-model
 go 1.14
 
 require (
+	github.com/gofrs/flock v0.8.0
 	github.com/golang/protobuf v1.4.3 // indirect
 	github.com/onosproject/onos-api/go v0.7.11
 	github.com/onosproject/onos-lib-go v0.7.5
@@ -12,6 +13,7 @@ require (
 	github.com/rogpeppe/go-internal v1.3.0
 	github.com/spf13/cobra v0.0.6
 	github.com/stretchr/testify v1.7.0
+	golang.org/x/sys v0.0.0-20210305215415-5cdee2b1b5a0 // indirect
 	google.golang.org/grpc v1.33.2
 	google.golang.org/protobuf v1.25.0
 	gopkg.in/yaml.v2 v2.3.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -61,6 +61,8 @@ github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2
 github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9GBnD5lWE=
 github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V4qmtdjCk=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
+github.com/gofrs/flock v0.8.0 h1:MSdYClljsF3PbENUUEx85nkWfJSGfzYI9yEBZOJz6CY=
+github.com/gofrs/flock v0.8.0/go.mod h1:F1TvTiK9OcQqauNUHlbJvyl9Qa1QvF/gOUDKA14jxHU=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.2.1/go.mod h1:hp+jE20tsWTFYpLwKvXlhS1hjn+gTNwPg2I6zVXpSg4=
 github.com/gogo/protobuf v1.3.1 h1:DqDEcV5aeaTmdFBePNpYsp3FlcVH/2ISVVM9Qf8PSls=
@@ -281,6 +283,8 @@ golang.org/x/sys v0.0.0-20200212091648-12a6c2dcc1e4/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200519105757-fe76b779f299 h1:DYfZAGf2WMFjMxbgTjaC+2HC7NkNAQs+6Q8b9WEB/F4=
 golang.org/x/sys v0.0.0-20200519105757-fe76b779f299/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210305215415-5cdee2b1b5a0 h1:MOJR6AyRlIYMexU2acorBot1aPks0cBDOyUA4hFlBhE=
+golang.org/x/sys v0.0.0-20210305215415-5cdee2b1b5a0/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2 h1:tW2bmiBqwgJj/UpqtC8EpXEZVYOwU0yG4iWbprSVAcs=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=

--- a/pkg/model/registry/registry_test.go
+++ b/pkg/model/registry/registry_test.go
@@ -30,6 +30,11 @@ func TestRegistry(t *testing.T) {
 	}
 	registry := NewConfigModelRegistry(config)
 
+	err = registry.RLock()
+	assert.NoError(t, err)
+	assert.True(t, registry.IsRLocked())
+	assert.False(t, registry.IsLocked())
+
 	_, err = registry.GetModel("foo", "1.0.0")
 	assert.Error(t, err)
 	assert.True(t, errors.IsNotFound(err))
@@ -37,6 +42,16 @@ func TestRegistry(t *testing.T) {
 	models, err := registry.ListModels()
 	assert.NoError(t, err)
 	assert.Len(t, models, 0)
+
+	err = registry.RUnlock()
+	assert.NoError(t, err)
+	assert.False(t, registry.IsRLocked())
+	assert.False(t, registry.IsLocked())
+
+	err = registry.Lock()
+	assert.NoError(t, err)
+	assert.True(t, registry.IsLocked())
+	assert.True(t, registry.IsRLocked())
 
 	model := configmodel.ModelInfo{
 		Name:    "foo",
@@ -72,4 +87,9 @@ func TestRegistry(t *testing.T) {
 	models, err = registry.ListModels()
 	assert.NoError(t, err)
 	assert.Len(t, models, 0)
+
+	err = registry.Unlock()
+	assert.NoError(t, err)
+	assert.False(t, registry.IsLocked())
+	assert.False(t, registry.IsRLocked())
 }


### PR DESCRIPTION
This PR adds a file lock to the model registry for concurrency control.