### PR TITLE
Cache versioned model plugins to avoid compiler cost

### DIFF
--- a/build/bin/build-images
+++ b/build/bin/build-images
@@ -11,6 +11,10 @@ do
     docker build . -f build/config-model-base/Dockerfile \
         --build-arg GOLANG_BUILD_VERSION=${build} \
         -t onosproject/config-model-base:${version}-golang-build-${build}
+    docker build . -f build/config-model-init/Dockerfile \
+        --build-arg GOLANG_BUILD_VERSION=${build} \
+        --build-arg CONFIG_MODEL_VERSION=${version} \
+        -t onosproject/config-model-init:${version}-golang-build-${build}
     docker build . -f build/config-model-compiler/Dockerfile \
         --build-arg GOLANG_BUILD_VERSION=${build} \
         --build-arg CONFIG_MODEL_VERSION=${version} \
@@ -21,5 +25,6 @@ do
         -t onosproject/config-model-registry:${version}-golang-build-${build}
 done
 
+docker tag onosproject/config-model-init:${version}-golang-build-${defbuild} onosproject/config-model-init:${version}
 docker tag onosproject/config-model-compiler:${version}-golang-build-${defbuild} onosproject/config-model-compiler:${version}
 docker tag onosproject/config-model-registry:${version}-golang-build-${defbuild} onosproject/config-model-registry:${version}

--- a/build/bin/load-images
+++ b/build/bin/load-images
@@ -8,9 +8,11 @@ shift
 
 for build in "$@"
 do
+    kind load docker-image onosproject/config-model-init:${version}-golang-build-${build}
     kind load docker-image onosproject/config-model-compiler:${version}-golang-build-${build}
     kind load docker-image onosproject/config-model-registry:${version}-golang-build-${build}
 done
 
+kind load docker-image onosproject/config-model-init:${version}
 kind load docker-image onosproject/config-model-compiler:${version}
 kind load docker-image onosproject/config-model-registry:${version}

--- a/build/bin/load-images
+++ b/build/bin/load-images
@@ -6,12 +6,12 @@ shift
 defbuild=$1
 shift
 
-for build in "$@"
-do
-    kind load docker-image onosproject/config-model-init:${version}-golang-build-${build}
-    kind load docker-image onosproject/config-model-compiler:${version}-golang-build-${build}
-    kind load docker-image onosproject/config-model-registry:${version}-golang-build-${build}
-done
+#for build in "$@"
+#do
+#    kind load docker-image onosproject/config-model-init:${version}-golang-build-${build}
+#    kind load docker-image onosproject/config-model-compiler:${version}-golang-build-${build}
+#    kind load docker-image onosproject/config-model-registry:${version}-golang-build-${build}
+#done
 
 kind load docker-image onosproject/config-model-init:${version}
 kind load docker-image onosproject/config-model-compiler:${version}

--- a/build/bin/push-images
+++ b/build/bin/push-images
@@ -6,9 +6,11 @@ shift
 
 for build in "$@"
 do
+    docker push onosproject/config-model-init:go-${version}-build-${build}
     docker push onosproject/config-model-compiler:go-${version}-build-${build}
     docker push onosproject/config-model-registry:go-${version}-build-${build}
 done
 
+docker push onosproject/config-model-init:go-${version}
 docker push onosproject/config-model-compiler:go-${version}
 docker push onosproject/config-model-registry:go-${version}

--- a/build/bin/push-images
+++ b/build/bin/push-images
@@ -4,13 +4,13 @@ echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USER" --password-stdin
 version=$1
 shift
 
-for build in "$@"
-do
-    docker push onosproject/config-model-init:go-${version}-build-${build}
-    docker push onosproject/config-model-compiler:go-${version}-build-${build}
-    docker push onosproject/config-model-registry:go-${version}-build-${build}
-done
+#for build in "$@"
+#do
+#    docker push onosproject/config-model-init:${version}-golang-build-${build}
+#    docker push onosproject/config-model-compiler:${version}-golang-build-${build}
+#    docker push onosproject/config-model-registry:${version}-golang-build-${build}
+#done
 
-docker push onosproject/config-model-init:go-${version}
-docker push onosproject/config-model-compiler:go-${version}
-docker push onosproject/config-model-registry:go-${version}
+docker push onosproject/config-model-init:${version}
+docker push onosproject/config-model-compiler:${version}
+docker push onosproject/config-model-registry:${version}

--- a/build/config-model-base/Dockerfile
+++ b/build/config-model-base/Dockerfile
@@ -11,3 +11,5 @@ RUN go mod download -x
 COPY logging.yaml /onos-config-model/
 COPY cmd /onos-config-model/cmd
 COPY pkg /onos-config-model/pkg
+
+RUN rm -rf /go/pkg/mod/cache

--- a/build/config-model-base/Dockerfile
+++ b/build/config-model-base/Dockerfile
@@ -9,6 +9,5 @@ WORKDIR /onos-config-model
 RUN go mod download -x
 
 COPY logging.yaml /onos-config-model/
-COPY api /onos-config-model/api
 COPY cmd /onos-config-model/cmd
 COPY pkg /onos-config-model/pkg

--- a/build/config-model-init/Dockerfile
+++ b/build/config-model-init/Dockerfile
@@ -1,0 +1,6 @@
+ARG GOLANG_BUILD_VERSION=latest
+ARG CONFIG_MODEL_VERSION=latest
+
+FROM onosproject/config-model-base:${CONFIG_MODEL_VERSION}-golang-build-${GOLANG_BUILD_VERSION}
+
+ENTRYPOINT ["go", "run", "github.com/onosproject/onos-config-model/cmd/config-model", "init"]

--- a/cmd/config-model/main.go
+++ b/cmd/config-model/main.go
@@ -78,16 +78,16 @@ func getCompileCmd() *cobra.Command {
 			version := configmodel.Version(v)
 			files, _ := cmd.Flags().GetStringSlice("file")
 			modules, _ := cmd.Flags().GetStringToString("module")
-			modulePath, _ := cmd.Flags().GetString("mod-path")
 			cachePath, _ := cmd.Flags().GetString("cache-path")
 			buildPath, _ := cmd.Flags().GetString("build-path")
-			target, _ := cmd.Flags().GetString("target")
-			replace, _ := cmd.Flags().GetString("replace")
+			modPath, _ := cmd.Flags().GetString("mod-path")
+			modTarget, _ := cmd.Flags().GetString("mod-target")
+			modReplace, _ := cmd.Flags().GetString("mod-replace")
 
 			resolverConfig := pluginmodule.ResolverConfig{
-				Path:    modulePath,
-				Target:  target,
-				Replace: replace,
+				Path:    modPath,
+				Target:  modTarget,
+				Replace: modReplace,
 			}
 			resolver := pluginmodule.NewResolver(resolverConfig)
 
@@ -158,8 +158,8 @@ func getCompileCmd() *cobra.Command {
 	cmd.Flags().StringP("version", "v", "", "the model version")
 	cmd.Flags().StringSliceP("file", "f", []string{}, "model files")
 	cmd.Flags().StringToStringP("module", "m", map[string]string{}, "model module descriptors")
-	cmd.Flags().StringP("target", "t", "", "the target Go module")
-	cmd.Flags().StringP("replace", "r", "", "the replace Go module")
+	cmd.Flags().StringP("mod-target", "t", "", "the target Go module")
+	cmd.Flags().StringP("mod-replace", "r", "", "the replace Go module")
 	cmd.Flags().StringP("mod-path", "m", defaultModPath, "the module path")
 	cmd.Flags().StringP("cache-path", "o", defaultCachePath, "the cache path")
 	cmd.Flags().StringP("build-path", "b", defaultBuildPath, "the build path")
@@ -172,21 +172,21 @@ func getInitCmd() *cobra.Command {
 		Short:        "Initializes the target module info",
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			target, _ := cmd.Flags().GetString("target")
-			replace, _ := cmd.Flags().GetString("replace")
-			path, _ := cmd.Flags().GetString("mod-path")
+			modPath, _ := cmd.Flags().GetString("mod-path")
+			modTarget, _ := cmd.Flags().GetString("mod-target")
+			modReplace, _ := cmd.Flags().GetString("mod-replace")
 			config := pluginmodule.ResolverConfig{
-				Path:    path,
-				Target:  target,
-				Replace: replace,
+				Path:    modPath,
+				Target:  modTarget,
+				Replace: modReplace,
 			}
 			manager := pluginmodule.NewResolver(config)
 			_, _, err := manager.Resolve()
 			return err
 		},
 	}
-	cmd.Flags().StringP("target", "t", "", "the target Go module")
-	cmd.Flags().StringP("replace", "r", "", "the replace Go module")
+	cmd.Flags().StringP("mod-target", "t", "", "the target Go module")
+	cmd.Flags().StringP("mod-replace", "r", "", "the replace Go module")
 	cmd.Flags().StringP("mod-path", "p", defaultModPath, "the module path")
 	return cmd
 }
@@ -214,10 +214,10 @@ func getRegistryServeCmd() *cobra.Command {
 			key, _ := cmd.Flags().GetString("key")
 			registryPath, _ := cmd.Flags().GetString("registry-path")
 			cachePath, _ := cmd.Flags().GetString("cache-path")
-			modPath, _ := cmd.Flags().GetString("mod-path")
 			buildPath, _ := cmd.Flags().GetString("build-path")
-			target, _ := cmd.Flags().GetString("target")
-			replace, _ := cmd.Flags().GetString("replace")
+			modPath, _ := cmd.Flags().GetString("mod-path")
+			modTarget, _ := cmd.Flags().GetString("mod-target")
+			modReplace, _ := cmd.Flags().GetString("mod-replace")
 			port, _ := cmd.Flags().GetInt16("port")
 
 			server := northbound.NewServer(&northbound.ServerConfig{
@@ -231,8 +231,8 @@ func getRegistryServeCmd() *cobra.Command {
 
 			resolverConfig := pluginmodule.ResolverConfig{
 				Path:    modPath,
-				Target:  target,
-				Replace: replace,
+				Target:  modTarget,
+				Replace: modReplace,
 			}
 			resolver := pluginmodule.NewResolver(resolverConfig)
 
@@ -275,13 +275,13 @@ func getRegistryServeCmd() *cobra.Command {
 	cmd.Flags().Int16P("port", "p", 5151, "the registry service port")
 	cmd.Flags().String("registry-path", defaultRegistryPath, "the path in which to store the registry models")
 	cmd.Flags().String("mod-path", defaultModPath, "the path in which to store the module info")
+	cmd.Flags().StringP("mod-target", "t", "", "the target Go module")
+	cmd.Flags().StringP("mod-replace", "r", "", "the replace Go module")
 	cmd.Flags().String("cache-path", defaultCachePath, "the path in which to store the plugins")
 	cmd.Flags().String("build-path", defaultBuildPath, "the path in which to store temporary build artifacts")
 	cmd.Flags().String("ca-cert", "", "the CA certificate")
 	cmd.Flags().String("cert", "", "the certificate")
 	cmd.Flags().String("key", "", "the key")
-	cmd.Flags().StringP("target", "t", "", "the target Go module")
-	cmd.Flags().StringP("replace", "r", "", "the replace Go module")
 	return cmd
 }
 

--- a/cmd/config-model/main.go
+++ b/cmd/config-model/main.go
@@ -43,10 +43,9 @@ var log = logging.GetLogger("config-model")
 
 const (
 	defaultCachePath    = "/etc/onos/plugins"
-	defaultRegistryPath = "/etc/onos/registry/models"
-	defaultModPath      = "/etc/onos/registry/module"
+	defaultRegistryPath = "/etc/onos/registry"
+	defaultModPath      = "/etc/onos/mod"
 	defaultBuildPath    = "/etc/onos/build"
-	defaultTemplatePath = "pkg/model/plugin/compiler/templates"
 )
 
 func main() {

--- a/cmd/config-model/main.go
+++ b/cmd/config-model/main.go
@@ -19,7 +19,6 @@ import (
 	"crypto/tls"
 	"encoding/json"
 	"errors"
-	"fmt"
 	configmodelapi "github.com/onosproject/onos-api/go/onos/configmodel"
 	"github.com/onosproject/onos-config-model/pkg/model"
 	"github.com/onosproject/onos-config-model/pkg/model/plugin/compiler"
@@ -157,41 +156,19 @@ func getInitCmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			target, _ := cmd.Flags().GetString("target")
 			replace, _ := cmd.Flags().GetString("replace")
-			hashPath, _ := cmd.Flags().GetString("hash-path")
-			modPath, _ := cmd.Flags().GetString("mod-path")
+			path, _ := cmd.Flags().GetString("mod-path")
 			config := module.ManagerConfig{
 				Target:  target,
 				Replace: replace,
+				Path:    path,
 			}
 			manager := module.NewManager(config)
-			mod, hash, err := manager.FetchMod()
-			if err != nil {
-				return err
-			}
-			bytes, err := mod.Format()
-			if err != nil {
-				return err
-			}
-			if hashPath != "" {
-				if err := ioutil.WriteFile(hashPath, hash, os.ModePerm); err != nil {
-					return err
-				}
-			} else {
-				fmt.Println(string(hash))
-			}
-			if modPath != "" {
-				if err := ioutil.WriteFile(modPath, bytes, os.ModePerm); err != nil {
-					return err
-				}
-			} else {
-				fmt.Println(string(bytes))
-			}
-			return nil
+			_, _, err := manager.FetchMod()
+			return err
 		},
 	}
 	cmd.Flags().StringP("target", "t", "", "the target Go module")
 	cmd.Flags().StringP("replace", "r", "", "the replace Go module")
-	cmd.Flags().StringP("hash-path", "b", "", "the hash path")
 	cmd.Flags().StringP("mod-path", "b", "", "the module path")
 	return cmd
 }

--- a/cmd/config-model/main.go
+++ b/cmd/config-model/main.go
@@ -112,8 +112,8 @@ func getCompileCmd() *cobra.Command {
 				Name:    name,
 				Version: version,
 				Plugin: configmodel.PluginInfo{
-					Name:    configmodel.Name(name),
-					Version: configmodel.Version(version),
+					Name:    name,
+					Version: version,
 				},
 			}
 

--- a/cmd/config-model/main.go
+++ b/cmd/config-model/main.go
@@ -159,7 +159,7 @@ func getCompileCmd() *cobra.Command {
 	cmd.Flags().StringToStringP("module", "m", map[string]string{}, "model module descriptors")
 	cmd.Flags().StringP("mod-target", "t", "", "the target Go module")
 	cmd.Flags().StringP("mod-replace", "r", "", "the replace Go module")
-	cmd.Flags().StringP("mod-path", "m", defaultModPath, "the module path")
+	cmd.Flags().StringP("mod-path", "p", defaultModPath, "the module path")
 	cmd.Flags().StringP("cache-path", "o", defaultCachePath, "the cache path")
 	cmd.Flags().StringP("build-path", "b", defaultBuildPath, "the build path")
 	return cmd
@@ -181,6 +181,9 @@ func getInitCmd() *cobra.Command {
 			}
 			manager := pluginmodule.NewResolver(config)
 			_, _, err := manager.Resolve()
+			if err != nil {
+				log.Errorf("Failed to initialize module '%s': %s", modTarget, err)
+			}
 			return err
 		},
 	}

--- a/pkg/model/plugin/cache/cache.go
+++ b/pkg/model/plugin/cache/cache.go
@@ -16,6 +16,7 @@ package plugincache
 
 import (
 	"context"
+	"encoding/base64"
 	"fmt"
 	"github.com/gofrs/flock"
 	configmodel "github.com/onosproject/onos-config-model/pkg/model"
@@ -108,7 +109,9 @@ func (c *PluginCache) GetPath(name configmodel.Name, version configmodel.Version
 	if err != nil {
 		return "", err
 	}
-	return filepath.Join(c.Config.Path, string(hash), fmt.Sprintf("%s-%s.so", name, version)), nil
+	var dir []byte
+	base64.URLEncoding.Encode(dir, hash)
+	return filepath.Join(c.Config.Path, string(dir), fmt.Sprintf("%s-%s.so", name, version)), nil
 }
 
 // Cached returns whether the given plugin is cached

--- a/pkg/model/plugin/cache/cache.go
+++ b/pkg/model/plugin/cache/cache.go
@@ -1,0 +1,139 @@
+// Copyright 2020-present Open Networking Foundation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package plugincache
+
+import (
+	"context"
+	"fmt"
+	"github.com/gofrs/flock"
+	configmodel "github.com/onosproject/onos-config-model/pkg/model"
+	modelplugin "github.com/onosproject/onos-config-model/pkg/model/plugin"
+	pluginmodule "github.com/onosproject/onos-config-model/pkg/model/plugin/module"
+	"github.com/onosproject/onos-lib-go/pkg/errors"
+	"github.com/onosproject/onos-lib-go/pkg/logging"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+var log = logging.GetLogger("config-model", "plugin", "cache")
+
+const (
+	defaultPath      = "/etc/onos/cache"
+	lockFileName     = "cache.lock"
+	lockAttemptDelay = 5 * time.Second
+)
+
+// CacheConfig is a plugin cache configuration
+type CacheConfig struct {
+	Path string `yaml:"path" json:"path"`
+}
+
+// NewPluginCache creates a new plugin cache
+func NewPluginCache(config CacheConfig, resolver *pluginmodule.Resolver) *PluginCache {
+	if config.Path == "" {
+		config.Path = defaultPath
+	}
+	return &PluginCache{
+		Config:   config,
+		resolver: resolver,
+		lock:     flock.New(filepath.Join(config.Path, lockFileName)),
+	}
+}
+
+// PluginCache is a model plugin cache
+type PluginCache struct {
+	Config   CacheConfig
+	resolver *pluginmodule.Resolver
+	lock     *flock.Flock
+}
+
+// Lock acquires a write lock on the cache
+func (c *PluginCache) Lock() error {
+	succeeded, err := c.lock.TryLockContext(context.Background(), lockAttemptDelay)
+	if err != nil {
+		return errors.NewInternal(err.Error())
+	} else if !succeeded {
+		return errors.NewConflict("failed to acquire cache lock")
+	}
+	return nil
+}
+
+// IsLocked checks whether the cache is write locked
+func (c *PluginCache) IsLocked() bool {
+	return c.lock.Locked()
+}
+
+// Unlock releases a write lock from the cache
+func (c *PluginCache) Unlock() error {
+	return c.lock.Unlock()
+}
+
+// RLock acquires a read lock on the cache
+func (c *PluginCache) RLock() error {
+	succeeded, err := c.lock.TryRLockContext(context.Background(), lockAttemptDelay)
+	if err != nil {
+		return errors.NewInternal(err.Error())
+	} else if !succeeded {
+		return errors.NewConflict("failed to acquire cache lock")
+	}
+	return nil
+}
+
+// IsRLocked checks whether the cache is read locked
+func (c *PluginCache) IsRLocked() bool {
+	return c.lock.Locked() || c.lock.RLocked()
+}
+
+// RUnlock releases a read lock on the cache
+func (c *PluginCache) RUnlock() error {
+	return c.lock.Unlock()
+}
+
+// GetPath gets the path of the given plugin
+func (c *PluginCache) GetPath(name configmodel.Name, version configmodel.Version) (string, error) {
+	_, hash, err := c.resolver.Resolve()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(c.Config.Path, string(hash), fmt.Sprintf("%s-%s.so", name, version)), nil
+}
+
+// Cached returns whether the given plugin is cached
+func (c *PluginCache) Cached(name configmodel.Name, version configmodel.Version) (bool, error) {
+	if !c.IsRLocked() {
+		return false, errors.NewConflict("cache is not locked")
+	}
+	path, err := c.GetPath(name, version)
+	if err != nil {
+		return false, err
+	}
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		return true, nil
+	}
+	return false, nil
+}
+
+// Load loads a plugin from the cache
+func (c *PluginCache) Load(name configmodel.Name, version configmodel.Version) (modelplugin.ConfigModelPlugin, error) {
+	if !c.IsRLocked() {
+		return nil, errors.NewConflict("cache is not locked")
+	}
+	path, err := c.GetPath(name, version)
+	if err != nil {
+		return nil, err
+	}
+	return modelplugin.Load(path)
+}

--- a/pkg/model/plugin/cache/cache.go
+++ b/pkg/model/plugin/cache/cache.go
@@ -31,7 +31,7 @@ import (
 var log = logging.GetLogger("config-model", "plugin", "cache")
 
 const (
-	defaultPath      = "/etc/onos/cache"
+	defaultPath      = "/etc/onos/plugins"
 	lockFileName     = "cache.lock"
 	lockAttemptDelay = 5 * time.Second
 )

--- a/pkg/model/plugin/compiler/compiler.go
+++ b/pkg/model/plugin/compiler/compiler.go
@@ -58,6 +58,11 @@ const (
 	modelFile  = "model.go"
 )
 
+const (
+	defaultBuildPath    = "/etc/onos/build"
+	defaultTemplatePath = "pkg/model/plugin/compiler/templates"
+)
+
 var (
 	_, b, _, _            = runtime.Caller(0)
 	moduleRoot            = filepath.Dir(filepath.Dir(filepath.Dir(filepath.Dir(filepath.Dir(b)))))
@@ -96,6 +101,12 @@ type CompilerConfig struct {
 
 // NewPluginCompiler creates a new model plugin compiler
 func NewPluginCompiler(config CompilerConfig, resolver *pluginmodule.Resolver) *PluginCompiler {
+	if config.BuildPath == "" {
+		config.BuildPath = defaultBuildPath
+	}
+	if config.TemplatePath == "" {
+		config.TemplatePath = defaultTemplatePath
+	}
 	return &PluginCompiler{
 		Config:   config,
 		resolver: resolver,

--- a/pkg/model/plugin/module/manager.go
+++ b/pkg/model/plugin/module/manager.go
@@ -1,0 +1,216 @@
+// Copyright 2021-present Open Networking Foundation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package module
+
+import (
+	"crypto/md5"
+	"encoding/json"
+	"fmt"
+	"github.com/onosproject/onos-lib-go/pkg/logging"
+	_ "github.com/openconfig/gnmi/proto/gnmi" // gnmi
+	_ "github.com/openconfig/goyang/pkg/yang" // yang
+	_ "github.com/openconfig/ygot/genutil"    // genutil
+	_ "github.com/openconfig/ygot/ygen"       // ygen
+	_ "github.com/openconfig/ygot/ygot"       // ygot
+	_ "github.com/openconfig/ygot/ytypes"     // ytypes
+	"github.com/rogpeppe/go-internal/modfile"
+	"github.com/rogpeppe/go-internal/module"
+	_ "google.golang.org/protobuf/proto" // proto
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path/filepath"
+)
+
+var log = logging.GetLogger("config-model", "plugin", "module")
+
+const (
+	modFile = "go.mod"
+)
+
+// Hash is a module hash
+type Hash []byte
+
+// ManagerConfig is a module manager configuration
+type ManagerConfig struct {
+	ModPath   string
+	BuildPath string
+	Target    string
+	Replace   string
+}
+
+// NewManager creates a new model plugin compiler
+func NewManager(config ManagerConfig) *Manager {
+	return &Manager{config}
+}
+
+// Manager is a module manager
+type Manager struct {
+	Config ManagerConfig
+}
+
+func (c *Manager) exec(dir string, name string, args ...string) (string, error) {
+	cmd := exec.Command(name, args...)
+	cmd.Dir = dir
+	cmd.Env = append(os.Environ(), "GO111MODULE=on", "CGO_ENABLED=1")
+	cmd.Stderr = os.Stderr
+	out, err := cmd.Output()
+	if err != nil {
+		return "", err
+	}
+	return string(out), nil
+}
+
+func (c *Manager) getGoEnv() (goEnv, error) {
+	wd, err := os.Getwd()
+	if err != nil {
+		return goEnv{}, err
+	}
+
+	envJSON, err := c.exec(wd, "go", "env", "-json", "GOPATH", "GOMODCACHE")
+	if err != nil {
+		return goEnv{}, err
+	}
+	env := goEnv{}
+	if err := json.Unmarshal([]byte(envJSON), &env); err != nil {
+		return goEnv{}, err
+	}
+	return env, nil
+}
+
+func (c *Manager) getGoModCacheDir() (string, error) {
+	env, err := c.getGoEnv()
+	if err != nil {
+		return "", err
+	}
+	modCache := env.GOMODCACHE
+	if modCache == "" {
+		// For Go 1.14 and older.
+		return filepath.Join(env.GOPATH, "pkg", "mod"), nil
+	}
+	return modCache, nil
+}
+
+func (c *Manager) FetchMod() (*modfile.File, Hash, error) {
+	target, replace := c.Config.Target, c.Config.Replace
+	targetPath, _, _ := module.SplitPathVersion(target)
+
+	log.Debugf("Fetching module '%s'", target)
+	tmpDir, err := ioutil.TempDir("", "config-model")
+	if err != nil {
+		log.Error(err)
+		return nil, nil, err
+	}
+	defer os.RemoveAll(tmpDir)
+
+	// Generate a temporary module with which to pull the target module
+	tmpMod := []byte("module m\n")
+	if replace != "" {
+		replacePath, replaceVersion, _ := module.SplitPathVersion(replace)
+		tmpMod = append(tmpMod, []byte(fmt.Sprintf("replace %s => %s %s\n", targetPath, replacePath, replaceVersion))...)
+	}
+
+	// Write the temporary module file
+	tmpModPath := filepath.Join(tmpDir, modFile)
+	if err := ioutil.WriteFile(tmpModPath, tmpMod, 0666); err != nil {
+		log.Error(err)
+		return nil, nil, err
+	}
+
+	// Add the target dependency to the temporary module and download the target module
+	if _, err := c.exec(tmpDir, "go", "get", "-d", target); err != nil {
+		log.Error(err)
+		return nil, nil, err
+	}
+
+	// Read the updated go.mod for the temporary module
+	tmpMod, err = ioutil.ReadFile(tmpModPath)
+	if err != nil {
+		log.Error(err)
+		return nil, nil, err
+	}
+
+	// Parse the updated go.mod for the temporary module
+	tmpModFile, err := modfile.Parse(tmpModPath, tmpMod, nil)
+	if err != nil {
+		log.Error(err)
+		return nil, nil, err
+	}
+
+	// Determine the path/version for the target module
+	var modPath string
+	var modVersion string
+	if replace == "" {
+		for _, require := range tmpModFile.Require {
+			if require.Mod.Path == targetPath {
+				modPath = require.Mod.Path
+				modVersion = require.Mod.Version
+				break
+			}
+		}
+	} else {
+		for _, replace := range tmpModFile.Replace {
+			if replace.Old.Path == targetPath {
+				modPath = replace.New.Path
+				modVersion = replace.New.Version
+				break
+			}
+		}
+	}
+
+	// Compute the hash for the target module
+	modBytes := append([]byte(modPath), []byte(modVersion)...)
+	modSum := md5.Sum(modBytes)
+	modHash := make(Hash, len(modSum))
+	for i, b := range modSum {
+		modHash[i] = b
+	}
+
+	// Encode the target dependency path
+	encPath, err := module.EncodePath(modPath)
+	if err != nil {
+		log.Error(err)
+		return nil, nil, err
+	}
+	modPath = encPath
+
+	// Lookup the Go cache from the environment
+	modCache, err := c.getGoModCacheDir()
+	if err != nil {
+		log.Error(err)
+		return nil, nil, err
+	}
+
+	// Read the target go.mod from the cache
+	cacheModPath := filepath.Join(modCache, "cache", "download", modPath, "@v", modVersion+".mod")
+	cacheMod, err := ioutil.ReadFile(cacheModPath)
+	if err != nil {
+		log.Error(err)
+		return nil, nil, err
+	}
+
+	// Parse the target go.mod
+	cacheModFile, err := modfile.Parse(cacheModPath, cacheMod, nil)
+	if err != nil {
+		log.Error(err)
+		return nil, nil, err
+	}
+	return cacheModFile, modHash, nil
+}
+
+type goEnv struct {
+	GOPATH     string
+	GOMODCACHE string
+}

--- a/pkg/model/plugin/module/resolver.go
+++ b/pkg/model/plugin/module/resolver.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package module
+package pluginmodule
 
 import (
 	"crypto/md5"
@@ -37,31 +37,31 @@ import (
 var log = logging.GetLogger("config-model", "plugin", "module")
 
 const (
-	modFile  = "go.mod"
-	hashFile = "mod.md5"
+	modFile     = "go.mod"
+	hashFile    = "mod.md5"
 )
 
 // Hash is a module hash
 type Hash []byte
 
-// ManagerConfig is a module manager configuration
-type ManagerConfig struct {
+// ResolverConfig is a module resolver configuration
+type ResolverConfig struct {
 	Path    string
 	Target  string
 	Replace string
 }
 
-// NewManager creates a new model plugin compiler
-func NewManager(config ManagerConfig) *Manager {
-	return &Manager{config}
+// NewResolver creates a new module resolver
+func NewResolver(config ResolverConfig) *Resolver {
+	return &Resolver{config}
 }
 
-// Manager is a module manager
-type Manager struct {
-	Config ManagerConfig
+// Resolver is a module resolver
+type Resolver struct {
+	Config ResolverConfig
 }
 
-func (m *Manager) exec(dir string, name string, args ...string) (string, error) {
+func (r *Resolver) exec(dir string, name string, args ...string) (string, error) {
 	cmd := exec.Command(name, args...)
 	cmd.Dir = dir
 	cmd.Env = append(os.Environ(), "GO111MODULE=on", "CGO_ENABLED=1")
@@ -73,13 +73,13 @@ func (m *Manager) exec(dir string, name string, args ...string) (string, error) 
 	return string(out), nil
 }
 
-func (m *Manager) getGoEnv() (goEnv, error) {
+func (r *Resolver) getGoEnv() (goEnv, error) {
 	wd, err := os.Getwd()
 	if err != nil {
 		return goEnv{}, err
 	}
 
-	envJSON, err := m.exec(wd, "go", "env", "-json", "GOPATH", "GOMODCACHE")
+	envJSON, err := r.exec(wd, "go", "env", "-json", "GOPATH", "GOMODCACHE")
 	if err != nil {
 		return goEnv{}, err
 	}
@@ -90,8 +90,8 @@ func (m *Manager) getGoEnv() (goEnv, error) {
 	return env, nil
 }
 
-func (m *Manager) getGoModCacheDir() (string, error) {
-	env, err := m.getGoEnv()
+func (r *Resolver) getGoModCacheDir() (string, error) {
+	env, err := r.getGoEnv()
 	if err != nil {
 		return "", err
 	}
@@ -103,21 +103,21 @@ func (m *Manager) getGoModCacheDir() (string, error) {
 	return modCache, nil
 }
 
-func (m *Manager) FetchMod() (*modfile.File, Hash, error) {
-	modPath := m.getModPath()
+func (r *Resolver) Resolve() (*modfile.File, Hash, error) {
+	modPath := r.getModPath()
 	modBytes, modErr := ioutil.ReadFile(modPath)
-	hashPath := m.getHashPath()
+	hashPath := r.getHashPath()
 	hashBytes, hashErr := ioutil.ReadFile(hashPath)
 	if modErr != nil || hashErr != nil {
-		mod, hash, err := m.fetchMod()
+		mod, hash, err := r.fetchMod()
 		modBytes, err := mod.Format()
 		if err != nil {
 			return nil, nil, err
 		}
-		if err := ioutil.WriteFile(m.getModPath(), modBytes, 0666); err != nil {
+		if err := ioutil.WriteFile(r.getModPath(), modBytes, 0666); err != nil {
 			return nil, nil, err
 		}
-		if err := ioutil.WriteFile(m.getHashPath(), hash, 0666); err != nil {
+		if err := ioutil.WriteFile(r.getHashPath(), hash, 0666); err != nil {
 			return nil, nil, err
 		}
 		return mod, hash, nil
@@ -129,8 +129,8 @@ func (m *Manager) FetchMod() (*modfile.File, Hash, error) {
 	return modFile, hashBytes, nil
 }
 
-func (m *Manager) fetchMod() (*modfile.File, Hash, error) {
-	target, replace := m.Config.Target, m.Config.Replace
+func (r *Resolver) fetchMod() (*modfile.File, Hash, error) {
+	target, replace := r.Config.Target, r.Config.Replace
 	targetPath, _, _ := module.SplitPathVersion(target)
 
 	log.Debugf("Fetching module '%s'", target)
@@ -156,7 +156,7 @@ func (m *Manager) fetchMod() (*modfile.File, Hash, error) {
 	}
 
 	// Add the target dependency to the temporary module and download the target module
-	if _, err := m.exec(tmpDir, "go", "get", "-d", target); err != nil {
+	if _, err := r.exec(tmpDir, "go", "get", "-d", target); err != nil {
 		log.Error(err)
 		return nil, nil, err
 	}
@@ -213,7 +213,7 @@ func (m *Manager) fetchMod() (*modfile.File, Hash, error) {
 	modPath = encPath
 
 	// Lookup the Go cache from the environment
-	modCache, err := m.getGoModCacheDir()
+	modCache, err := r.getGoModCacheDir()
 	if err != nil {
 		log.Error(err)
 		return nil, nil, err
@@ -243,12 +243,12 @@ func (m *Manager) fetchMod() (*modfile.File, Hash, error) {
 	return modFile, modHash, nil
 }
 
-func (m *Manager) getModPath() string {
-	return filepath.Join(m.Config.Path, modFile)
+func (r *Resolver) getModPath() string {
+	return filepath.Join(r.Config.Path, modFile)
 }
 
-func (m *Manager) getHashPath() string {
-	return filepath.Join(m.Config.Path, hashFile)
+func (r *Resolver) getHashPath() string {
+	return filepath.Join(r.Config.Path, hashFile)
 }
 
 type goEnv struct {

--- a/pkg/model/plugin/module/resolver.go
+++ b/pkg/model/plugin/module/resolver.go
@@ -18,6 +18,7 @@ import (
 	"crypto/md5"
 	"encoding/json"
 	"fmt"
+	"github.com/onosproject/onos-lib-go/pkg/errors"
 	"github.com/onosproject/onos-lib-go/pkg/logging"
 	_ "github.com/openconfig/gnmi/proto/gnmi" // gnmi
 	_ "github.com/openconfig/goyang/pkg/yang" // yang
@@ -37,6 +38,7 @@ import (
 var log = logging.GetLogger("config-model", "plugin", "module")
 
 const (
+	defaultPath = "/etc/onos/mod"
 	modFile     = "go.mod"
 	hashFile    = "mod.md5"
 )
@@ -53,6 +55,9 @@ type ResolverConfig struct {
 
 // NewResolver creates a new module resolver
 func NewResolver(config ResolverConfig) *Resolver {
+	if config.Path == "" {
+		config.Path = defaultPath
+	}
 	return &Resolver{config}
 }
 
@@ -131,6 +136,10 @@ func (r *Resolver) Resolve() (*modfile.File, Hash, error) {
 
 func (r *Resolver) fetchMod() (*modfile.File, Hash, error) {
 	target, replace := r.Config.Target, r.Config.Replace
+	if target == "" {
+		return nil, nil, errors.NewInvalid("no target module configured")
+	}
+
 	targetPath, _, _ := module.SplitPathVersion(target)
 
 	log.Debugf("Fetching module '%s'", target)

--- a/pkg/model/registry/registry.go
+++ b/pkg/model/registry/registry.go
@@ -37,6 +37,7 @@ const (
 )
 
 const (
+	defaultPath = "/etc/onos/registry"
 	defaultTarget = "github.com/onosproject/onos-config"
 )
 
@@ -49,6 +50,9 @@ type Config struct {
 
 // NewConfigModelRegistry creates a new config model registry
 func NewConfigModelRegistry(config Config) *ConfigModelRegistry {
+	if config.Path == "" {
+		config.Path = defaultPath
+	}
 	if _, err := os.Stat(config.Path); os.IsNotExist(err) {
 		err = os.MkdirAll(config.Path, os.ModePerm)
 		if err != nil {

--- a/pkg/model/registry/registry.go
+++ b/pkg/model/registry/registry.go
@@ -15,12 +15,9 @@
 package modelregistry
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/gofrs/flock"
 	"github.com/onosproject/onos-config-model/pkg/model"
-	"github.com/onosproject/onos-config-model/pkg/model/plugin"
 	"github.com/onosproject/onos-lib-go/pkg/errors"
 	"github.com/onosproject/onos-lib-go/pkg/logging"
 	"github.com/rogpeppe/go-internal/module"
@@ -28,7 +25,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"time"
+	"sync"
 )
 
 const jsonExt = ".json"
@@ -41,11 +38,6 @@ const (
 
 const (
 	defaultTarget = "github.com/onosproject/onos-config"
-)
-
-const (
-	lockFileName     = "registry.lock"
-	lockAttemptDelay = 5 * time.Second
 )
 
 var log = logging.GetLogger("config-model", "registry")
@@ -65,7 +57,6 @@ func NewConfigModelRegistry(config Config) *ConfigModelRegistry {
 	}
 	return &ConfigModelRegistry{
 		Config: config,
-		lock:   flock.New(filepath.Join(config.Path, lockFileName)),
 	}
 }
 
@@ -82,56 +73,13 @@ func NewConfigModelRegistryFromEnv() *ConfigModelRegistry {
 // ConfigModelRegistry is a registry of config models
 type ConfigModelRegistry struct {
 	Config Config
-	lock   *flock.Flock
-}
-
-// Lock acquires a write lock on the registry
-func (r *ConfigModelRegistry) Lock() error {
-	succeeded, err := r.lock.TryLockContext(context.Background(), lockAttemptDelay)
-	if err != nil {
-		return errors.NewInternal(err.Error())
-	} else if !succeeded {
-		return errors.NewConflict("failed to acquire registry lock")
-	}
-	return nil
-}
-
-// IsLocked checks whether the registry is write locked
-func (r *ConfigModelRegistry) IsLocked() bool {
-	return r.lock.Locked()
-}
-
-// Unlock releases a write lock from the registry
-func (r *ConfigModelRegistry) Unlock() error {
-	return r.lock.Unlock()
-}
-
-// RLock acquires a read lock on the registry
-func (r *ConfigModelRegistry) RLock() error {
-	succeeded, err := r.lock.TryRLockContext(context.Background(), lockAttemptDelay)
-	if err != nil {
-		return errors.NewInternal(err.Error())
-	} else if !succeeded {
-		return errors.NewConflict("failed to acquire registry lock")
-	}
-	return nil
-}
-
-// IsRLocked checks whether the registry is read locked
-func (r *ConfigModelRegistry) IsRLocked() bool {
-	return r.lock.Locked() || r.lock.RLocked()
-}
-
-// RUnlock releases a read lock on the registry
-func (r *ConfigModelRegistry) RUnlock() error {
-	return r.lock.Unlock()
+	mu     sync.RWMutex
 }
 
 // GetModel gets a model by name and version
 func (r *ConfigModelRegistry) GetModel(name configmodel.Name, version configmodel.Version) (configmodel.ModelInfo, error) {
-	if !r.IsRLocked() {
-		return configmodel.ModelInfo{}, errors.NewConflict("registry is not locked")
-	}
+	r.mu.RLock()
+	defer r.mu.RUnlock()
 	path := r.getDescriptorFile(name, version)
 	log.Debugf("Loading model definition '%s'", path)
 	model, err := loadModel(path)
@@ -144,10 +92,8 @@ func (r *ConfigModelRegistry) GetModel(name configmodel.Name, version configmode
 
 // ListModels lists models in the registry
 func (r *ConfigModelRegistry) ListModels() ([]configmodel.ModelInfo, error) {
-	if !r.IsRLocked() {
-		return nil, errors.NewConflict("registry is not locked")
-	}
-
+	r.mu.RLock()
+	defer r.mu.RUnlock()
 	log.Debugf("Loading models from '%s'", r.Config.Path)
 	var modelFiles []string
 	err := filepath.Walk(r.Config.Path, func(file string, info os.FileInfo, err error) error {
@@ -176,10 +122,8 @@ func (r *ConfigModelRegistry) ListModels() ([]configmodel.ModelInfo, error) {
 
 // AddModel adds a model to the registry
 func (r *ConfigModelRegistry) AddModel(model configmodel.ModelInfo) error {
-	if !r.IsLocked() {
-		return errors.NewConflict("registry is not locked")
-	}
-
+	r.mu.Lock()
+	defer r.mu.Unlock()
 	log.Debugf("Adding model '%s/%s' to registry '%s'", model.Name, model.Version, r.Config.Path)
 	bytes, err := json.MarshalIndent(model, "", "  ")
 	if err != nil {
@@ -187,7 +131,7 @@ func (r *ConfigModelRegistry) AddModel(model configmodel.ModelInfo) error {
 		return err
 	}
 	path := r.getDescriptorFile(model.Name, model.Version)
-	if err := ioutil.WriteFile(path, bytes, os.ModePerm); err != nil {
+	if err := ioutil.WriteFile(path, bytes, 0666); err != nil {
 		log.Errorf("Adding model '%s/%s' failed: %v", model.Name, model.Version, err)
 		return err
 	}
@@ -197,10 +141,8 @@ func (r *ConfigModelRegistry) AddModel(model configmodel.ModelInfo) error {
 
 // RemoveModel removes a model from the registry
 func (r *ConfigModelRegistry) RemoveModel(name configmodel.Name, version configmodel.Version) error {
-	if !r.IsLocked() {
-		return errors.NewConflict("registry is not locked")
-	}
-
+	r.mu.Lock()
+	defer r.mu.Unlock()
 	log.Debugf("Deleting model '%s/%s' from registry '%s'", name, version, r.Config.Path)
 	path := r.getDescriptorFile(name, version)
 	if _, err := os.Stat(path); !os.IsNotExist(err) {
@@ -211,18 +153,6 @@ func (r *ConfigModelRegistry) RemoveModel(name configmodel.Name, version configm
 	}
 	log.Infof("Model '%s/%s' deleted from registry '%s'", name, version, r.Config.Path)
 	return nil
-}
-
-// LoadPlugin loads a plugin from the registry
-func (r *ConfigModelRegistry) LoadPlugin(name configmodel.Name, version configmodel.Version) (modelplugin.ConfigModelPlugin, error) {
-	if !r.IsRLocked() {
-		return nil, errors.NewConflict("registry is not locked")
-	}
-	return modelplugin.Load(r.getPluginFile(name, version))
-}
-
-func (r *ConfigModelRegistry) getPluginFile(name configmodel.Name, version configmodel.Version) string {
-	return filepath.Join(r.Config.Path, fmt.Sprintf("%s-%s.so", name, version))
 }
 
 func (r *ConfigModelRegistry) getDescriptorFile(name configmodel.Name, version configmodel.Version) string {

--- a/pkg/model/registry/registry.go
+++ b/pkg/model/registry/registry.go
@@ -31,13 +31,7 @@ import (
 const jsonExt = ".json"
 
 const (
-	modelRegistryEnv = "CONFIG_MODEL_REGISTRY"
-	targetModuleEnv  = "CONFIG_MODULE_TARGET"
-	replaceModuleEnv = "CONFIG_MODULE_REPLACE"
-)
-
-const (
-	defaultPath = "/etc/onos/registry"
+	defaultPath   = "/etc/onos/registry"
 	defaultTarget = "github.com/onosproject/onos-config"
 )
 
@@ -62,16 +56,6 @@ func NewConfigModelRegistry(config Config) *ConfigModelRegistry {
 	return &ConfigModelRegistry{
 		Config: config,
 	}
-}
-
-// NewConfigModelRegistryFromEnv creates a new config model registry from the environment
-func NewConfigModelRegistryFromEnv() *ConfigModelRegistry {
-	dir, target, replace := os.Getenv(modelRegistryEnv), os.Getenv(targetModuleEnv), os.Getenv(replaceModuleEnv)
-	path, err := GetPath(dir, target, replace)
-	if err != nil {
-		panic(err)
-	}
-	return NewConfigModelRegistry(Config{Path: path})
 }
 
 // ConfigModelRegistry is a registry of config models

--- a/pkg/model/registry/registry_test.go
+++ b/pkg/model/registry/registry_test.go
@@ -30,11 +30,6 @@ func TestRegistry(t *testing.T) {
 	}
 	registry := NewConfigModelRegistry(config)
 
-	err = registry.RLock()
-	assert.NoError(t, err)
-	assert.True(t, registry.IsRLocked())
-	assert.False(t, registry.IsLocked())
-
 	_, err = registry.GetModel("foo", "1.0.0")
 	assert.Error(t, err)
 	assert.True(t, errors.IsNotFound(err))
@@ -42,16 +37,6 @@ func TestRegistry(t *testing.T) {
 	models, err := registry.ListModels()
 	assert.NoError(t, err)
 	assert.Len(t, models, 0)
-
-	err = registry.RUnlock()
-	assert.NoError(t, err)
-	assert.False(t, registry.IsRLocked())
-	assert.False(t, registry.IsLocked())
-
-	err = registry.Lock()
-	assert.NoError(t, err)
-	assert.True(t, registry.IsLocked())
-	assert.True(t, registry.IsRLocked())
 
 	model := configmodel.ModelInfo{
 		Name:    "foo",
@@ -87,9 +72,4 @@ func TestRegistry(t *testing.T) {
 	models, err = registry.ListModels()
 	assert.NoError(t, err)
 	assert.Len(t, models, 0)
-
-	err = registry.Unlock()
-	assert.NoError(t, err)
-	assert.False(t, registry.IsLocked())
-	assert.False(t, registry.IsRLocked())
 }


### PR DESCRIPTION
This PR provides new features to facilitate more granular control over the compiler/registry by the operator. 

The `cache` package provides caching for model plugins. Plugins are read from a cache and are only compiled in the event of a cache miss. To ensure each plugin is only compiled once for all pods, a file lock is added to the cache for concurrency control. While a plugin is being compiled, a write lock is held on the plugin cache.

It's of course critical that compiled plugins in the cache be versioned by the onos-config binary version/dependencies, and the `module` package uses the Go module system to compute versions for plugins. To version the plugins, a new `init` container is added to determine the version of the target onos-config module for versioning model plugins. The init container fetches the Go module info for the target onos-config module and uses the `ziphash` computed by Go (the same hash used in `go.sum` files) to provide a version for plugins. Fetching the target module info in an initial `init` container serves also to avoid repeated downloads while compiling plugins. The module info that's retrieved during startup is cached on a shared volume for the compiler to use to compile all plugins for the pod.

With plugins being read from a cache, the model registry really just serves as a metadata store now. Once a pod is started, the operator must enable each plugin via the registry API. If a plugin is not found, it will be compiled on the fly. If a plugin is found, its metadata is added to the registry.