### PR TITLE
Fix build bugs and inefficiencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,9 +4,6 @@ export GO111MODULE=on
 .PHONY: build
 
 ONOS_CONFIG_MODEL_VERSION ?= latest
-ONOS_PROTOC_VERSION := v0.6.7
-GOLANG_BUILD_VERSIONS  := v0.6.3 v0.6.6
-DEFAULT_GOLANG_BUILD_VERSION := v0.6.3
 
 PHONY:build
 build: # @HELP build all libraries
@@ -43,12 +40,6 @@ license_check: build-tools # @HELP examine and ensure license headers exist
 gofmt: # @HELP run the Go format validation
 	bash -c "diff -u <(echo -n) <(gofmt -d pkg/)"
 
-protos: # @HELP compile the protobuf files (using protoc-go Docker)
-	docker run -it -v `pwd`:/go/src/github.com/onosproject/onos-config-model \
-		-w /go/src/github.com/onosproject/onos-config-model \
-		--entrypoint build/bin/compile-protos.sh \
-		onosproject/protoc-go:${ONOS_PROTOC_VERSION}
-
 compile-plugins: # @HELP compile standard plugins
 compile-plugins:
 	docker run \
@@ -74,15 +65,15 @@ serve:
 		--build-path /onos-config-model/build
 
 images:
-	./build/bin/build-images ${ONOS_CONFIG_MODEL_VERSION} ${DEFAULT_GOLANG_BUILD_VERSION} ${GOLANG_BUILD_VERSIONS}
+	./build/bin/build-images ${ONOS_CONFIG_MODEL_VERSION}
 
 kind: # @HELP build Docker images and add them to the currently configured kind cluster
 kind: images
 	@if [ "`kind get clusters`" = '' ]; then echo "no kind cluster found" && exit 1; fi
-	./build/bin/load-images ${ONOS_CONFIG_MODEL_VERSION} ${DEFAULT_GOLANG_BUILD_VERSION} ${GOLANG_BUILD_VERSIONS}
+	./build/bin/load-images ${ONOS_CONFIG_MODEL_VERSION}
 
 push: images
-	./build/bin/push-images ${ONOS_CONFIG_MODEL_VERSION} ${GOLANG_BUILD_VERSIONS}
+	./build/bin/push-images ${ONOS_CONFIG_MODEL_VERSION}
 
 publish: # @HELP publish version on github and dockerhub
 	./../build-tools/publish-version ${VERSION} onosproject/onos-kpimon

--- a/build/bin/build-images
+++ b/build/bin/build-images
@@ -1,30 +1,18 @@
 #!/bin/bash
 
 version=$1
-shift
 
-defbuild=$1
-shift
-
-for build in "$@"
-do
-    docker build . -f build/config-model-base/Dockerfile \
-        --build-arg GOLANG_BUILD_VERSION=${build} \
-        -t onosproject/config-model-base:${version}-golang-build-${build}
-    docker build . -f build/config-model-init/Dockerfile \
-        --build-arg GOLANG_BUILD_VERSION=${build} \
-        --build-arg CONFIG_MODEL_VERSION=${version} \
-        -t onosproject/config-model-init:${version}-golang-build-${build}
-    docker build . -f build/config-model-compiler/Dockerfile \
-        --build-arg GOLANG_BUILD_VERSION=${build} \
-        --build-arg CONFIG_MODEL_VERSION=${version} \
-        -t onosproject/config-model-compiler:${version}-golang-build-${build}
-    docker build . -f build/config-model-registry/Dockerfile \
-        --build-arg GOLANG_BUILD_VERSION=${build} \
-        --build-arg CONFIG_MODEL_VERSION=${version} \
-        -t onosproject/config-model-registry:${version}-golang-build-${build}
-done
-
-docker tag onosproject/config-model-init:${version}-golang-build-${defbuild} onosproject/config-model-init:${version}
-docker tag onosproject/config-model-compiler:${version}-golang-build-${defbuild} onosproject/config-model-compiler:${version}
-docker tag onosproject/config-model-registry:${version}-golang-build-${defbuild} onosproject/config-model-registry:${version}
+docker build . -f build/config-model-build/Dockerfile \
+    -t onosproject/config-model-build:${version}
+docker build . -f build/config-model-base/Dockerfile \
+    --build-arg CONFIG_MODEL_VERSION=${version} \
+    -t onosproject/config-model-base:${version}
+docker build . -f build/config-model-init/Dockerfile \
+    --build-arg CONFIG_MODEL_VERSION=${version} \
+    -t onosproject/config-model-init:${version}
+docker build . -f build/config-model-compiler/Dockerfile \
+    --build-arg CONFIG_MODEL_VERSION=${version} \
+    -t onosproject/config-model-compiler:${version}
+docker build . -f build/config-model-registry/Dockerfile \
+    --build-arg CONFIG_MODEL_VERSION=${version} \
+    -t onosproject/config-model-registry:${version}

--- a/build/bin/compile-protos.sh
+++ b/build/bin/compile-protos.sh
@@ -1,5 +1,0 @@
-#!/bin/sh
-
-proto_imports=".:${GOPATH}/src/github.com/gogo/protobuf/protobuf:${GOPATH}/src/github.com/gogo/protobuf:${GOPATH}/src"
-
-protoc -I=$proto_imports --gogofaster_out=import_path=github.com/onosproject/onos-config-model/api/onos/configmodel,plugins=grpc:. api/onos/configmodel/*.proto

--- a/build/bin/load-images
+++ b/build/bin/load-images
@@ -1,17 +1,6 @@
 #!/bin/bash
 
 version=$1
-shift
-
-defbuild=$1
-shift
-
-#for build in "$@"
-#do
-#    kind load docker-image onosproject/config-model-init:${version}-golang-build-${build}
-#    kind load docker-image onosproject/config-model-compiler:${version}-golang-build-${build}
-#    kind load docker-image onosproject/config-model-registry:${version}-golang-build-${build}
-#done
 
 kind load docker-image onosproject/config-model-init:${version}
 kind load docker-image onosproject/config-model-compiler:${version}

--- a/build/bin/push-images
+++ b/build/bin/push-images
@@ -2,15 +2,8 @@
 echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USER" --password-stdin
 
 version=$1
-shift
 
-#for build in "$@"
-#do
-#    docker push onosproject/config-model-init:${version}-golang-build-${build}
-#    docker push onosproject/config-model-compiler:${version}-golang-build-${build}
-#    docker push onosproject/config-model-registry:${version}-golang-build-${build}
-#done
-
+docker push onosproject/config-model-build:${version}
 docker push onosproject/config-model-init:${version}
 docker push onosproject/config-model-compiler:${version}
 docker push onosproject/config-model-registry:${version}

--- a/build/config-model-base/Dockerfile
+++ b/build/config-model-base/Dockerfile
@@ -1,6 +1,6 @@
 ARG CONFIG_MODEL_VERSION=latest
 
-FROM onosproject/cofig-model-build:$CONFIG_MODEL_VERSION
+FROM onosproject/config-model-build:$CONFIG_MODEL_VERSION
 
 COPY go.mod go.sum /onos-config-model/
 

--- a/build/config-model-base/Dockerfile
+++ b/build/config-model-base/Dockerfile
@@ -1,6 +1,6 @@
-ARG GOLANG_BUILD_VERSION=latest
+ARG CONFIG_MODEL_VERSION=latest
 
-FROM onosproject/golang-build:$GOLANG_BUILD_VERSION
+FROM onosproject/cofig-model-build:$CONFIG_MODEL_VERSION
 
 COPY go.mod go.sum /onos-config-model/
 

--- a/build/config-model-build/Dockerfile
+++ b/build/config-model-build/Dockerfile
@@ -2,15 +2,6 @@ FROM golang:1.14-alpine3.13
 
 RUN apk upgrade --update --no-cache
 
-RUN export GO111MODULE=on && \
-    go get -u github.com/golang/protobuf/protoc-gen-go && \
-    go get -u google.golang.org/protobuf/proto && \
-    go get -u golang.org/x/lint/golint && \
-    go get -u github.com/fzipp/gocyclo && \
-    go get -u github.com/client9/misspell/cmd/misspell && \
-    go get -u github.com/gordonklaus/ineffassign && \
-    go get -u github.com/openconfig/ygot/generator
-
 RUN mkdir /build
 
 WORKDIR /build

--- a/build/config-model-build/Dockerfile
+++ b/build/config-model-build/Dockerfile
@@ -1,6 +1,6 @@
 FROM golang:1.14-alpine3.13
 
-RUN apk upgrade --update --no-cache
+RUN apk upgrade --update --no-cache && apk add --update make gcc musl-dev
 
 RUN mkdir /build
 

--- a/build/config-model-build/Dockerfile
+++ b/build/config-model-build/Dockerfile
@@ -1,0 +1,18 @@
+FROM golang:1.14-alpine3.13
+
+RUN apk upgrade --update --no-cache
+
+RUN export GO111MODULE=on && \
+    go get -u github.com/golang/protobuf/protoc-gen-go && \
+    go get -u google.golang.org/protobuf/proto && \
+    go get -u golang.org/x/lint/golint && \
+    go get -u github.com/fzipp/gocyclo && \
+    go get -u github.com/client9/misspell/cmd/misspell && \
+    go get -u github.com/gordonklaus/ineffassign && \
+    go get -u github.com/openconfig/ygot/generator
+
+RUN mkdir /build
+
+WORKDIR /build
+
+ENTRYPOINT ["make"]

--- a/build/config-model-compiler/Dockerfile
+++ b/build/config-model-compiler/Dockerfile
@@ -1,6 +1,5 @@
-ARG GOLANG_BUILD_VERSION=latest
 ARG CONFIG_MODEL_VERSION=latest
 
-FROM onosproject/config-model-base:${CONFIG_MODEL_VERSION}-golang-build-${GOLANG_BUILD_VERSION}
+FROM onosproject/config-model-base:${CONFIG_MODEL_VERSION}
 
 ENTRYPOINT ["go", "run", "github.com/onosproject/onos-config-model/cmd/config-model", "compile"]

--- a/build/config-model-init/Dockerfile
+++ b/build/config-model-init/Dockerfile
@@ -1,6 +1,5 @@
-ARG GOLANG_BUILD_VERSION=latest
 ARG CONFIG_MODEL_VERSION=latest
 
-FROM onosproject/config-model-base:${CONFIG_MODEL_VERSION}-golang-build-${GOLANG_BUILD_VERSION}
+FROM onosproject/config-model-base:${CONFIG_MODEL_VERSION}
 
 ENTRYPOINT ["go", "run", "github.com/onosproject/onos-config-model/cmd/config-model", "init"]

--- a/build/config-model-registry/Dockerfile
+++ b/build/config-model-registry/Dockerfile
@@ -1,6 +1,5 @@
-ARG GOLANG_BUILD_VERSION=latest
 ARG CONFIG_MODEL_VERSION=latest
 
-FROM onosproject/config-model-base:${CONFIG_MODEL_VERSION}-golang-build-${GOLANG_BUILD_VERSION}
+FROM onosproject/config-model-base:${CONFIG_MODEL_VERSION}
 
 ENTRYPOINT ["go", "run", "github.com/onosproject/onos-config-model/cmd/config-model", "registry", "serve"]

--- a/cmd/config-model/main.go
+++ b/cmd/config-model/main.go
@@ -94,11 +94,11 @@ func getCompileCmd() *cobra.Command {
 				Path: cachePath,
 			}
 			cache := plugincache.NewPluginCache(cacheConfig, resolver)
-			if err := cache.Lock(); err != nil {
+			if err := cache.Lock(context.Background()); err != nil {
 				return err
 			}
 			defer func() {
-				_ = cache.Unlock()
+				_ = cache.Unlock(context.Background())
 			}()
 
 			cached, err := cache.Cached(name, version)

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/onosproject/onos-config-model
 go 1.14
 
 require (
-	github.com/gofrs/flock v0.8.0
 	github.com/golang/protobuf v1.4.3 // indirect
 	github.com/onosproject/onos-api/go v0.7.11
 	github.com/onosproject/onos-lib-go v0.7.5

--- a/go.sum
+++ b/go.sum
@@ -61,8 +61,6 @@ github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2
 github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9GBnD5lWE=
 github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V4qmtdjCk=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
-github.com/gofrs/flock v0.8.0 h1:MSdYClljsF3PbENUUEx85nkWfJSGfzYI9yEBZOJz6CY=
-github.com/gofrs/flock v0.8.0/go.mod h1:F1TvTiK9OcQqauNUHlbJvyl9Qa1QvF/gOUDKA14jxHU=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.2.1/go.mod h1:hp+jE20tsWTFYpLwKvXlhS1hjn+gTNwPg2I6zVXpSg4=
 github.com/gogo/protobuf v1.3.1 h1:DqDEcV5aeaTmdFBePNpYsp3FlcVH/2ISVVM9Qf8PSls=

--- a/pkg/model/plugin/cache/cache.go
+++ b/pkg/model/plugin/cache/cache.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
-	"github.com/gofrs/flock"
 	configmodel "github.com/onosproject/onos-config-model/pkg/model"
 	modelplugin "github.com/onosproject/onos-config-model/pkg/model/plugin"
 	pluginmodule "github.com/onosproject/onos-config-model/pkg/model/plugin/module"
@@ -27,6 +26,7 @@ import (
 	"os"
 	"path/filepath"
 	"sync"
+	"syscall"
 	"time"
 )
 
@@ -58,20 +58,19 @@ func NewPluginCache(config CacheConfig, resolver *pluginmodule.Resolver) *Plugin
 type PluginCache struct {
 	Config   CacheConfig
 	resolver *pluginmodule.Resolver
-	lock     *flock.Flock
+	path     string
+	rlocked  bool
+	wlocked  bool
+	fh       *os.File
 	mu       sync.RWMutex
 }
 
 // Lock acquires a write lock on the cache
-func (c *PluginCache) Lock() error {
-	lock, err := c.getLock()
-	if err != nil {
-		return err
-	}
-	succeeded, err := lock.TryLockContext(context.Background(), lockAttemptDelay)
+func (c *PluginCache) Lock(ctx context.Context) error {
+	locked, err := c.lock(ctx, &c.wlocked, syscall.LOCK_EX)
 	if err != nil {
 		return errors.NewInternal(err.Error())
-	} else if !succeeded {
+	} else if !locked {
 		return errors.NewConflict("failed to acquire cache lock")
 	}
 	return nil
@@ -80,30 +79,21 @@ func (c *PluginCache) Lock() error {
 // IsLocked checks whether the cache is write locked
 func (c *PluginCache) IsLocked() bool {
 	c.mu.RLock()
-	lock := c.lock
-	c.mu.RUnlock()
-	return lock != nil && lock.Locked()
+	defer c.mu.RUnlock()
+	return c.wlocked
 }
 
 // Unlock releases a write lock from the cache
-func (c *PluginCache) Unlock() error {
-	lock, err := c.getLock()
-	if err != nil {
-		return err
-	}
-	return lock.Unlock()
+func (c *PluginCache) Unlock(ctx context.Context) error {
+	return c.unlock(ctx)
 }
 
 // RLock acquires a read lock on the cache
-func (c *PluginCache) RLock() error {
-	lock, err := c.getLock()
-	if err != nil {
-		return err
-	}
-	succeeded, err := lock.TryRLockContext(context.Background(), lockAttemptDelay)
+func (c *PluginCache) RLock(ctx context.Context) error {
+	locked, err := c.lock(ctx, &c.rlocked, syscall.LOCK_SH)
 	if err != nil {
 		return errors.NewInternal(err.Error())
-	} else if !succeeded {
+	} else if !locked {
 		return errors.NewConflict("failed to acquire cache lock")
 	}
 	return nil
@@ -112,52 +102,104 @@ func (c *PluginCache) RLock() error {
 // IsRLocked checks whether the cache is read locked
 func (c *PluginCache) IsRLocked() bool {
 	c.mu.RLock()
-	lock := c.lock
-	c.mu.RUnlock()
-	return lock != nil && (lock.Locked() || lock.RLocked())
+	defer c.mu.RUnlock()
+	return c.wlocked || c.rlocked
 }
 
 // RUnlock releases a read lock on the cache
-func (c *PluginCache) RUnlock() error {
-	lock, err := c.getLock()
-	if err != nil {
-		return err
-	}
-	return lock.Unlock()
+func (c *PluginCache) RUnlock(ctx context.Context) error {
+	return c.unlock(ctx)
 }
 
-// getLock gets the cache lock for the resolved module target, initializing the lock with the
-// correct permissions (0666) if necessary
-func (c *PluginCache) getLock() (*flock.Flock, error) {
-	c.mu.RLock()
-	lock := c.lock
-	c.mu.RUnlock()
-	if lock != nil {
-		return lock, nil
+// lock attempts to acquire a file lock
+func (c *PluginCache) lock(ctx context.Context, locked *bool, flag int) (bool, error) {
+	for {
+		if ok, err := c.tryLock(locked, flag); ok || err != nil {
+			return ok, err
+		}
+		select {
+		case <-ctx.Done():
+			return false, ctx.Err()
+		case <-time.After(lockAttemptDelay):
+			// try again
+		}
 	}
+}
 
+func (c *PluginCache) tryLock(locked *bool, flag int) (bool, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	cacheDir, err := c.getModCache()
-	if err != nil {
-		return nil, err
+	if *locked {
+		return true, nil
 	}
 
-	if _, err := os.Stat(cacheDir); os.IsNotExist(err) {
-		if err := os.MkdirAll(cacheDir, os.ModePerm); err != nil {
-			return nil, err
+	if c.fh == nil {
+		if err := c.openFH(); err != nil {
+			return false, err
 		}
+		defer c.ensureFhState()
 	}
 
-	file := filepath.Join(cacheDir, lockFileName)
-	if _, err = os.Create(file); err != nil {
-		return nil, err
+	err := syscall.Flock(int(c.fh.Fd()), flag|syscall.LOCK_NB)
+	switch err {
+	case syscall.EWOULDBLOCK:
+		return false, nil
+	case nil:
+		*locked = true
+		return true, nil
+	}
+	return false, err
+}
+
+func (c *PluginCache) unlock(ctx context.Context) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if (!c.wlocked && !c.rlocked) || c.fh == nil {
+		return nil
 	}
 
-	lock = flock.New(file)
-	c.lock = lock
-	return lock, nil
+	if err := syscall.Flock(int(c.fh.Fd()), syscall.LOCK_UN); err != nil {
+		return err
+	}
+
+	c.fh.Close()
+
+	c.wlocked = false
+	c.rlocked = false
+	c.fh = nil
+	return nil
+}
+
+func (c *PluginCache) openFH() error {
+	if c.path == "" {
+		cacheDir, err := c.getModCache()
+		if err != nil {
+			return err
+		}
+
+		if _, err := os.Stat(cacheDir); os.IsNotExist(err) {
+			if err := os.MkdirAll(cacheDir, os.ModePerm); err != nil {
+				return err
+			}
+		}
+		c.path = filepath.Join(cacheDir, lockFileName)
+	}
+
+	fh, err := os.OpenFile(c.path, os.O_CREATE|os.O_RDONLY, os.FileMode(0666))
+	if err != nil {
+		return err
+	}
+	c.fh = fh
+	return nil
+}
+
+func (c *PluginCache) ensureFhState() {
+	if !c.wlocked && !c.rlocked && c.fh != nil {
+		c.fh.Close()
+		c.fh = nil
+	}
 }
 
 // getModCache gets the cache directory for the module target

--- a/pkg/model/plugin/cache/cache.go
+++ b/pkg/model/plugin/cache/cache.go
@@ -64,6 +64,7 @@ type PluginCache struct {
 
 // Lock acquires a write lock on the cache
 func (c *PluginCache) Lock() error {
+	ensureDir(filepath.Join(c.Config.Path, lockFileName))
 	succeeded, err := c.lock.TryLockContext(context.Background(), lockAttemptDelay)
 	if err != nil {
 		return errors.NewInternal(err.Error())
@@ -85,6 +86,7 @@ func (c *PluginCache) Unlock() error {
 
 // RLock acquires a read lock on the cache
 func (c *PluginCache) RLock() error {
+	ensureDir(filepath.Join(c.Config.Path, lockFileName))
 	succeeded, err := c.lock.TryRLockContext(context.Background(), lockAttemptDelay)
 	if err != nil {
 		return errors.NewInternal(err.Error())

--- a/pkg/model/plugin/compiler/compiler_test.go
+++ b/pkg/model/plugin/compiler/compiler_test.go
@@ -15,6 +15,7 @@
 package plugincompiler
 
 import (
+	"context"
 	"github.com/onosproject/onos-config-model/pkg/model"
 	plugincache "github.com/onosproject/onos-config-model/pkg/model/plugin/cache"
 	pluginmodule "github.com/onosproject/onos-config-model/pkg/model/plugin/module"
@@ -67,7 +68,7 @@ func TestCompiler(t *testing.T) {
 		},
 	}
 
-	err = cache.Lock()
+	err = cache.Lock(context.TODO())
 	assert.NoError(t, err)
 
 	outputPath, err := cache.GetPath("test", "1.0.0")
@@ -81,6 +82,6 @@ func TestCompiler(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, plugin)
 
-	err = cache.Unlock()
+	err = cache.Unlock(context.TODO())
 	assert.NoError(t, err)
 }

--- a/pkg/model/registry/server.go
+++ b/pkg/model/registry/server.go
@@ -126,19 +126,19 @@ func (s *Server) ListModels(ctx context.Context, request *configmodelapi.ListMod
 // PushModel :
 func (s *Server) PushModel(ctx context.Context, request *configmodelapi.PushModelRequest) (*configmodelapi.PushModelResponse, error) {
 	log.Debugf("Received PushModelRequest %+v", request)
-	if err := s.cache.Lock(); err != nil {
+	if err := s.cache.Lock(ctx); err != nil {
 		log.Errorf("Failed to acquire cache lock: %s", err)
 		return nil, errors.Status(err).Err()
 	}
 
 	defer func() {
 		if err := recover(); err != nil {
-			_ = s.cache.Unlock()
+			_ = s.cache.Unlock(context.Background())
 		}
 	}()
 
 	defer func() {
-		if err := s.cache.Unlock(); err != nil {
+		if err := s.cache.Unlock(context.Background()); err != nil {
 			log.Errorf("Failed to release cache lock: %s", err)
 		}
 	}()


### PR DESCRIPTION
The PR implements a custom file lock inside the plugin cache to resolve a permission issue with locks shared across multiple containers. Additionally, it optimizes the build process, adding a lightweight `config-model-build` image to be used by onos-config and the plugin compiler to compile codes.