### PR TITLE
Prime module dependencies during initialization

### DIFF
--- a/cmd/config-model/main.go
+++ b/cmd/config-model/main.go
@@ -89,6 +89,9 @@ func getCompileCmd() *cobra.Command {
 				Replace: modReplace,
 			}
 			resolver := pluginmodule.NewResolver(resolverConfig)
+			if _, _, err := resolver.Resolve(); err != nil {
+				return err
+			}
 
 			cacheConfig := plugincache.CacheConfig{
 				Path: cachePath,


### PR DESCRIPTION
This PR adds a step to the init container to prime the dependencies by running `go mod download` during init.