### PR TITLE
Reduce logging output for clarity

### DIFF
--- a/logging.yaml
+++ b/logging.yaml
@@ -1,6 +1,6 @@
 loggers:
   root:
-    level: debug
+    level: info
     output:
       stdout:
         sink: stdout

--- a/pkg/model/configmodel.go
+++ b/pkg/model/configmodel.go
@@ -15,6 +15,7 @@
 package configmodel
 
 import (
+	"fmt"
 	"github.com/openconfig/gnmi/proto/gnmi"
 	"github.com/openconfig/goyang/pkg/yang"
 	"github.com/openconfig/ygot/ygot"
@@ -55,6 +56,10 @@ type ModelInfo struct {
 	Files   []FileInfo   `json:"files"`
 	Modules []ModuleInfo `json:"modules"`
 	Plugin  PluginInfo   `json:"plugin"`
+}
+
+func (m ModelInfo) String() string {
+	return fmt.Sprintf("%s@%s", m.Name, m.Version)
 }
 
 // ModuleInfo is a config module info

--- a/pkg/model/registry/registry.go
+++ b/pkg/model/registry/registry.go
@@ -73,8 +73,9 @@ func (r *ConfigModelRegistry) GetModel(name configmodel.Name, version configmode
 	model, err := loadModel(path)
 	if err != nil {
 		log.Warnf("Failed loading model definition '%s': %v", path, err)
+		return configmodel.ModelInfo{}, err
 	}
-	log.Infof("Loaded model '%s': %s", path, model)
+	log.Infof("Loaded model definition '%s': %s", path, model)
 	return model, err
 }
 

--- a/pkg/model/registry/server.go
+++ b/pkg/model/registry/server.go
@@ -148,10 +148,10 @@ func (s *Server) PushModel(ctx context.Context, request *configmodelapi.PushMode
 	// First check the registry for the model
 	_, err := s.registry.GetModel(name, version)
 	if err == nil {
-		err = errors.NewAlreadyExists("model '%s/%s' already exists", request.Model.Name, request.Model.Version)
+		err = errors.NewAlreadyExists("model '%s@%s' already exists", request.Model.Name, request.Model.Version)
 	}
 	if err != nil && !errors.IsNotFound(err) {
-		log.Warnf("PushModelRequest %+v failed: %v", request, err)
+		log.Warnf("PushModelRequest '%s@%s' failed: %s", request.Model.Name, request.Model.Version, err)
 		return nil, errors.Status(err).Err()
 	}
 
@@ -187,7 +187,7 @@ func (s *Server) PushModel(ctx context.Context, request *configmodelapi.PushMode
 	// Look for the plugin in the cache
 	cached, err := s.cache.Cached(name, version)
 	if err != nil {
-		log.Warnf("PushModelRequest %+v failed: %v", request, err)
+		log.Warnf("PushModelRequest '%s@%s' failed: %s", request.Model.Name, request.Model.Version, err)
 		return nil, errors.Status(err).Err()
 	}
 
@@ -195,12 +195,12 @@ func (s *Server) PushModel(ctx context.Context, request *configmodelapi.PushMode
 	if !cached {
 		path, err := s.cache.GetPath(name, version)
 		if err != nil {
-			log.Warnf("PushModelRequest %+v failed: %v", request, err)
+			log.Warnf("PushModelRequest '%s@%s' failed: %s", request.Model.Name, request.Model.Version, err)
 			return nil, errors.Status(err).Err()
 		}
 		err = s.compiler.CompilePlugin(modelInfo, path)
 		if err != nil {
-			log.Warnf("PushModelRequest %+v failed: %v", request, err)
+			log.Warnf("PushModelRequest '%s@%s' failed: %s", request.Model.Name, request.Model.Version, err)
 			return nil, errors.Status(err).Err()
 		}
 	}
@@ -208,7 +208,7 @@ func (s *Server) PushModel(ctx context.Context, request *configmodelapi.PushMode
 	// Add the model to the registry
 	err = s.registry.AddModel(modelInfo)
 	if err != nil {
-		log.Warnf("PushModelRequest %+v failed: %v", request, err)
+		log.Warnf("PushModelRequest '%s@%s' failed: %s", request.Model.Name, request.Model.Version, err)
 		return nil, errors.Status(err).Err()
 	}
 	response := &configmodelapi.PushModelResponse{}


### PR DESCRIPTION
Log model name/version rather than outputting tons of useless YANG data (which can still be found in the DEBUG logs).