### PR TITLE
Compile plugins asynchronously in registry server

### DIFF
--- a/pkg/model/registry/registry.go
+++ b/pkg/model/registry/registry.go
@@ -76,7 +76,7 @@ func (r *ConfigModelRegistry) GetModel(name configmodel.Name, version configmode
 		return configmodel.ModelInfo{}, err
 	}
 	log.Infof("Loaded model definition '%s': %s", path, model)
-	return model, err
+	return model, nil
 }
 
 // ListModels lists models in the registry


### PR DESCRIPTION
This PR modifies the registry server to compile plugins asynchronously in the background. This allows the operator to reconcile multiple models more quickly and allows the registry to compile multiple plugins in parallel. Write locks on the plugins being compiled ensures that any attempts to read a plugin while it's being compiled will be blocked until compilation is complete.