### PR TITLE
Prime cache in build image to reduce compile times

### DIFF
--- a/build/config-model-base/Dockerfile
+++ b/build/config-model-base/Dockerfile
@@ -11,5 +11,3 @@ RUN go mod download -x
 COPY logging.yaml /onos-config-model/
 COPY cmd /onos-config-model/cmd
 COPY pkg /onos-config-model/pkg
-
-RUN rm -rf /go/pkg/mod/cache

--- a/build/config-model-build/Dockerfile
+++ b/build/config-model-build/Dockerfile
@@ -1,8 +1,14 @@
 FROM golang:1.14-alpine3.13
 
-RUN apk upgrade --update --no-cache && apk add --update make gcc musl-dev
+RUN apk upgrade --update --no-cache && apk add --update make gcc musl-dev git
 
-RUN mkdir /build
+RUN mkdir -p /build/deps && \
+    cd /build/deps && \
+    echo "module deps" > go.mod && \
+    go get -u -d github.com/onosproject/onos-config && \
+    go get -u -d github.com/openconfig/ygot/generator && \
+    go mod download -x && \
+    rm -r /build/deps
 
 WORKDIR /build
 

--- a/pkg/model/plugin/module/resolver.go
+++ b/pkg/model/plugin/module/resolver.go
@@ -155,7 +155,7 @@ func (r *Resolver) fetchMod() (*modfile.File, Hash, error) {
 	targetPath, _ := splitModPathVersion(target)
 
 	log.Infof("Fetching module '%s'", target)
-	fakeModDir, err := ioutil.TempDir("", "config-model-download")
+	fakeModDir, err := ioutil.TempDir("", "config-plugin-target")
 	if err != nil {
 		log.Errorf("Failed to fetch module '%s': %s", r.Config.Target, err)
 		return nil, nil, err
@@ -243,34 +243,6 @@ func (r *Resolver) fetchMod() (*modfile.File, Hash, error) {
 	// Parse the target go.mod
 	targetModFile, err := modfile.Parse(cacheModPath, modBytes, nil)
 	if err != nil {
-		log.Errorf("Failed to fetch module '%s': %s", r.Config.Target, err)
-		return nil, nil, err
-	}
-
-	// Create a temporary directory for the target module
-	targetModDir, err := ioutil.TempDir("", "config-model-deps")
-	if err != nil {
-		log.Errorf("Failed to fetch module '%s': %s", r.Config.Target, err)
-		return nil, nil, err
-	}
-	defer os.RemoveAll(targetModDir)
-
-	// Format the target go.mod file
-	targetModBytes, err := targetModFile.Format()
-	if err != nil {
-		log.Errorf("Failed to fetch module '%s': %s", r.Config.Target, err)
-		return nil, nil, err
-	}
-
-	// Write the target go.mod file
-	targetModPath := filepath.Join(targetModDir, "go.mod")
-	if err := ioutil.WriteFile(targetModPath, targetModBytes, 0666); err != nil {
-		log.Errorf("Failed to fetch module '%s': %s", r.Config.Target, err)
-		return nil, nil, err
-	}
-
-	// Add the target dependency to the temporary module and download the target module
-	if _, err := r.exec(targetModDir, "go", "mod", "download"); err != nil {
 		log.Errorf("Failed to fetch module '%s': %s", r.Config.Target, err)
 		return nil, nil, err
 	}


### PR DESCRIPTION
This PR attempts to reduce download/compile times for plugins by priming the Go cache with the expected dependencies. When compiling plugins, dependencies should only have to be downloaded when they've been changed.