### PR TITLE
Fix concurrency control in registry server

### DIFF
--- a/pkg/model/plugin/cache/cache.go
+++ b/pkg/model/plugin/cache/cache.go
@@ -49,7 +49,7 @@ func NewPluginCache(config CacheConfig, resolver *pluginmodule.Resolver) (*Plugi
 		return nil, err
 	}
 
-	config.Path = filepath.Join(config.Path, base64.URLEncoding.EncodeToString(hash))
+	config.Path = filepath.Join(config.Path, base64.RawURLEncoding.EncodeToString(hash))
 	if _, err := os.Stat(config.Path); os.IsNotExist(err) {
 		if err := os.MkdirAll(config.Path, os.ModePerm); err != nil {
 			return nil, err

--- a/pkg/model/registry/server.go
+++ b/pkg/model/registry/server.go
@@ -194,12 +194,6 @@ func (s *Server) PushModel(ctx context.Context, request *configmodelapi.PushMode
 		}
 	}()
 
-	defer func() {
-		if err := entry.Unlock(context.Background()); err != nil {
-			log.Errorf("Failed to release cache lock: %s", err)
-		}
-	}()
-
 	// Add the model to the registry
 	err = s.registry.AddModel(modelInfo)
 	if err != nil {


### PR DESCRIPTION
The registry server releases its lock on model plugin files too soon. Plugins are compiled in the background, but the server releases the lock, allowing onos-config to attempt to read the plugin before it has finished being compiled. 